### PR TITLE
fix: add type field for some websocket replies that were missing it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "krist",
-  "version": "2.8.13",
+  "version": "2.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.8.13",
+      "name": "krist",
+      "version": "2.9.3",
       "license": "GPL-3.0",
       "dependencies": {
         "@octokit/rest": "^18.0.12",
@@ -20,7 +21,7 @@
         "express-handlebars": "^5.2.0",
         "express-rate-limit": "^5.2.6",
         "express-slow-down": "^1.4.0",
-        "express-ws": "^1.0.0-rc.2",
+        "express-ws": "^5.0.2",
         "gitlog": "^2.1.2",
         "handlebars": "^4.7.7",
         "handy-redis": "^2.1.0",
@@ -644,7 +645,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
       "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.2.0"
@@ -1611,11 +1612,17 @@
       }
     },
     "node_modules/express-ws": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-1.0.0.tgz",
-      "integrity": "sha1-GsMWjygjIYFipmtRK6WO+fr98OY=",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-5.0.2.tgz",
+      "integrity": "sha512-0uvmuk61O9HXgLhGl3QhNSEtRsQevtmbL94/eILaliEADZBHZOQUAiHFrGPrgsjikohyrmSG5g+sCfASTt0lkQ==",
       "dependencies": {
-        "ws": "^1.0.0"
+        "ws": "^7.4.6"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      },
+      "peerDependencies": {
+        "express": "^4.0.0 || ^5.0.0-alpha.1"
       }
     },
     "node_modules/express/node_modules/body-parser": {
@@ -3287,7 +3294,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
       "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -3485,14 +3492,6 @@
       "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
       "bin": {
         "opencollective-postinstall": "index.js"
-      }
-    },
-    "node_modules/options": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/p-cancelable": {
@@ -4716,11 +4715,6 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
-    "node_modules/ultron": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
-    },
     "node_modules/undefsafe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.3.tgz",
@@ -4817,7 +4811,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
       "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.2.0"
@@ -5094,12 +5088,23 @@
       }
     },
     "node_modules/ws": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-      "dependencies": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xdg-basedir": {
@@ -5731,7 +5736,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
       "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "node-gyp-build": "^4.2.0"
       }
@@ -6645,11 +6650,11 @@
       }
     },
     "express-ws": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-1.0.0.tgz",
-      "integrity": "sha1-GsMWjygjIYFipmtRK6WO+fr98OY=",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-5.0.2.tgz",
+      "integrity": "sha512-0uvmuk61O9HXgLhGl3QhNSEtRsQevtmbL94/eILaliEADZBHZOQUAiHFrGPrgsjikohyrmSG5g+sCfASTt0lkQ==",
       "requires": {
-        "ws": "^1.0.0"
+        "ws": "^7.4.6"
       }
     },
     "ext": {
@@ -7863,7 +7868,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
       "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-      "dev": true
+      "devOptional": true
     },
     "nodemon": {
       "version": "2.0.4",
@@ -8016,11 +8021,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
       "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
-    },
-    "options": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
     },
     "p-cancelable": {
       "version": "1.1.0",
@@ -9019,11 +9019,6 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
-    "ultron": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
-    },
     "undefsafe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.3.tgz",
@@ -9104,7 +9099,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.4.tgz",
       "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "node-gyp-build": "^4.2.0"
       }
@@ -9340,13 +9335,10 @@
       }
     },
     "ws": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-      "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
-      }
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "krist",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "The new Krist node written in node.js.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "krist",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "The new Krist node written in node.js.",
   "main": "index.js",
   "scripts": {
@@ -31,7 +31,7 @@
     "express-handlebars": "^5.2.0",
     "express-rate-limit": "^5.2.6",
     "express-slow-down": "^1.4.0",
-    "express-ws": "^1.0.0-rc.2",
+    "express-ws": "^5.0.2",
     "gitlog": "^2.1.2",
     "handlebars": "^4.7.7",
     "handy-redis": "^2.1.0",

--- a/src/routes/websockets.js
+++ b/src/routes/websockets.js
@@ -55,11 +55,15 @@ module.exports = function(app) {
       });
     } catch (error) {
       console.log(chalk`{red [Websockets]} Failed connection using token {bold ${token}} ${logDetails}`);
-
-      utils.sendErrorToWS(ws, error);
       console.error(error);
 
-      ws.close();
+      if (ws.readyState === ws.OPEN) {
+        utils.sendErrorToWS(ws, error);
+        ws.close();
+      } else {
+        // Just in case
+        websockets.removeWebsocket(ws, token);
+      }
     }
   });
 

--- a/src/websockets.js
+++ b/src/websockets.js
@@ -132,11 +132,7 @@ WebsocketsManager.prototype.addWebsocket = function(req, socket, token, auth, pk
   promWebsocketConnectionsTotal.inc({ type: ws.isGuest ? "guest" : "authed" });
 
   socket.on("close", function() {
-    const id = Websockets.websockets.indexOf(ws);
-
-    if (id !== -1) {
-      Websockets.websockets.splice(id, 1);
-    }
+    Websockets.removeWebsocket(ws);
   });
 
   socket.on("message", function(message) {
@@ -196,7 +192,21 @@ WebsocketsManager.prototype.addWebsocket = function(req, socket, token, auth, pk
     }
   });
 
+  socket.on("error", function(err) {
+    console.error("Fatal websocket error:", err);
+  });
+
   Websockets.websockets.push(ws);
+};
+
+WebsocketsManager.prototype.removeWebsocket = function(socket, token) {
+  const id = token
+    ? this.websockets.findIndex(v => v.token == token)
+    : this.websockets.indexOf(socket);
+
+  if (id !== -1) {
+    this.websockets.splice(id, 1);
+  }
 };
 
 WebsocketsManager.prototype.broadcast = function(message) {


### PR DESCRIPTION
This adds "type": "response" for successful websocket API responses, as
well as "type": "error" for an error case that was lacking it before.